### PR TITLE
refactor: dto class 네이밍 규칙 적용 및 @Builder 애노테이션 제거

### DIFF
--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/BoxOfficeResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/BoxOfficeResult.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.boxoffice.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/daily/DailyBoxOfficeRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/daily/DailyBoxOfficeRequestDto.java
@@ -5,11 +5,9 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/daily/DailyBoxOfficeResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/daily/DailyBoxOfficeResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.boxoffice.dto.daily;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/daily/DailyBoxOfficeResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/daily/DailyBoxOfficeResult.java
@@ -5,11 +5,9 @@ import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/weekly/WeeklyBoxOfficeRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/weekly/WeeklyBoxOfficeRequestDto.java
@@ -5,11 +5,9 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/weekly/WeeklyBoxOfficeResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/weekly/WeeklyBoxOfficeResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.boxoffice.dto.weekly;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/weekly/WeeklyBoxOfficeResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/boxoffice/dto/weekly/WeeklyBoxOfficeResult.java
@@ -5,11 +5,9 @@ import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfo.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfo.java
@@ -1,16 +1,14 @@
 package inno.escape.moviebatch.domain.company.dto.info;
 
-import inno.escape.moviebatch.global.model.dto.Filmo;
-import inno.escape.moviebatch.global.model.dto.Part;
+import inno.escape.moviebatch.global.model.dto.FilmoDto;
+import inno.escape.moviebatch.global.model.dto.PartDto;
 import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
@@ -26,7 +24,7 @@ public class CompanyInfo implements Serializable {
 
   private String ceoNm;
 
-  private List<Part> parts;
+  private List<PartDto> parts;
 
-  private List<Filmo> filmos;
+  private List<FilmoDto> filmos;
 }

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfoRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfoRequestDto.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfoResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfoResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.company.dto.info;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfoResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/info/CompanyInfoResult.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.company.dto.info;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyList.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyList.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.company.dto.list;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyListRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyListRequestDto.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyListResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyListResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.company.dto.list;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyListResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/company/dto/list/CompanyListResult.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfo.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfo.java
@@ -1,22 +1,20 @@
 package inno.escape.moviebatch.domain.movie.dto.info;
 
-import inno.escape.moviebatch.global.model.dto.Actor;
-import inno.escape.moviebatch.global.model.dto.Audit;
-import inno.escape.moviebatch.global.model.dto.Company;
-import inno.escape.moviebatch.global.model.dto.Director;
-import inno.escape.moviebatch.global.model.dto.Genre;
-import inno.escape.moviebatch.global.model.dto.Nation;
-import inno.escape.moviebatch.global.model.dto.ShowType;
-import inno.escape.moviebatch.global.model.dto.Staff;
+import inno.escape.moviebatch.global.model.dto.ActorDto;
+import inno.escape.moviebatch.global.model.dto.AuditDto;
+import inno.escape.moviebatch.global.model.dto.CompanyDto;
+import inno.escape.moviebatch.global.model.dto.DirectorDto;
+import inno.escape.moviebatch.global.model.dto.GenreDto;
+import inno.escape.moviebatch.global.model.dto.NationDto;
+import inno.escape.moviebatch.global.model.dto.ShowTypeDto;
+import inno.escape.moviebatch.global.model.dto.StaffDto;
 import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
@@ -42,19 +40,19 @@ public class MovieInfo implements Serializable {
 
   private String typeNm;
 
-  private List<Nation> nations;
+  private List<NationDto> nations;
 
-  private List<Genre> genres;
+  private List<GenreDto> genres;
 
-  private List<Director> directors;
+  private List<DirectorDto> directors;
 
-  private List<Actor> actors;
+  private List<ActorDto> actors;
 
-  private List<ShowType> showTypes;
+  private List<ShowTypeDto> showTypes;
 
-  private List<Company> companys;
+  private List<CompanyDto> companys;
 
-  private List<Audit> audits;
+  private List<AuditDto> audits;
 
-  private List<Staff> staffs;
+  private List<StaffDto> staffs;
 }

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfoRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfoRequestDto.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfoResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfoResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.movie.dto.info;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfoResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/info/MovieInfoResult.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.movie.dto.info;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieList.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieList.java
@@ -1,16 +1,14 @@
 package inno.escape.moviebatch.domain.movie.dto.list;
 
-import inno.escape.moviebatch.global.model.dto.Company;
-import inno.escape.moviebatch.global.model.dto.Director;
+import inno.escape.moviebatch.global.model.dto.CompanyDto;
+import inno.escape.moviebatch.global.model.dto.DirectorDto;
 import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
@@ -40,8 +38,8 @@ public class MovieList implements Serializable {
 
   private String repGenreNm;
 
-  private List<Director> directors;
+  private List<DirectorDto> directors;
 
-  private List<Company> companys;
+  private List<CompanyDto> companys;
 }
 

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieListRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieListRequestDto.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieListResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieListResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.movie.dto.list;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieListResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/movie/dto/list/MovieListResult.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/Filmo.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/Filmo.java
@@ -1,10 +1,11 @@
 package inno.escape.moviebatch.domain.moviepeople.dto.info;
 
-import lombok.*;
-
 import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfo.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfo.java
@@ -2,14 +2,11 @@ package inno.escape.moviebatch.domain.moviepeople.dto.info;
 
 import java.io.Serializable;
 import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfoRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfoRequestDto.java
@@ -1,11 +1,12 @@
 package inno.escape.moviebatch.domain.moviepeople.dto.info;
 
-import lombok.*;
-
-import javax.validation.constraints.NotBlank;
 import java.io.Serializable;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfoResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfoResponseDto.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.moviepeople.dto.info;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfoResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/info/PeopleInfoResult.java
@@ -1,10 +1,11 @@
 package inno.escape.moviebatch.domain.moviepeople.dto.info;
 
-import lombok.*;
-
 import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleList.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleList.java
@@ -3,11 +3,9 @@ package inno.escape.moviebatch.domain.moviepeople.dto.list;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleListRequestDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleListRequestDto.java
@@ -4,11 +4,9 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleListResponseDto.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleListResponseDto.java
@@ -1,15 +1,11 @@
 package inno.escape.moviebatch.domain.moviepeople.dto.list;
 
 import java.io.Serializable;
-import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleListResult.java
+++ b/src/main/java/inno/escape/moviebatch/domain/moviepeople/dto/list/PeopleListResult.java
@@ -1,11 +1,12 @@
 package inno.escape.moviebatch.domain.moviepeople.dto.list;
 
-import lombok.*;
-
 import java.io.Serializable;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data

--- a/src/main/java/inno/escape/moviebatch/global/Constants.java
+++ b/src/main/java/inno/escape/moviebatch/global/Constants.java
@@ -38,4 +38,8 @@ public class Constants {
       return value;
     }
   }
+
+  public enum AGE_LIMIT {
+
+  }
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/ActorDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/ActorDto.java
@@ -3,19 +3,21 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Genre implements Serializable {
+public class ActorDto implements Serializable {
 
-  private static final long serialVersionUID = -8848202206185624551L;
+  private static final long serialVersionUID = -3129364442384658519L;
 
-  private String genreNm;
+  private String peopleNm;
 
-  private String genreNmEn;
+  private String peopleNmEn;
+
+  private String cast;
+
+  private String castEn;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/AuditDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/AuditDto.java
@@ -3,23 +3,17 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Company implements Serializable {
+public class AuditDto implements Serializable {
 
-  private static final long serialVersionUID = -5244357870496464861L;
+  private static final long serialVersionUID = -2894116262379544856L;
 
-  private String companyCd;
+  private String auditNo;
 
-  private String companyNm;
-
-  private String companyNmEn;
-
-  private String companyPartNm;
+  private String watchGrandeNm;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/CompanyDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/CompanyDto.java
@@ -3,19 +3,21 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Director implements Serializable {
+public class CompanyDto implements Serializable {
 
-  private static final long serialVersionUID = 659751890165584695L;
+  private static final long serialVersionUID = -5244357870496464861L;
 
-  private String peopleNm;
+  private String companyCd;
 
-  private String peopleNmEn;
+  private String companyNm;
+
+  private String companyNmEn;
+
+  private String companyPartNm;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/DirectorDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/DirectorDto.java
@@ -3,23 +3,17 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Actor implements Serializable {
+public class DirectorDto implements Serializable {
 
-  private static final long serialVersionUID = -3129364442384658519L;
+  private static final long serialVersionUID = 659751890165584695L;
 
   private String peopleNm;
 
   private String peopleNmEn;
-
-  private String cast;
-
-  private String castEn;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/FilmoDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/FilmoDto.java
@@ -3,19 +3,19 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Nation implements Serializable {
+public class FilmoDto implements Serializable {
 
-  private static final long serialVersionUID = -4061994493958405357L;
+  private static final long serialVersionUID = -4053066014700162783L;
 
-  private String nationNm;
+  private String movieCd;
 
-  private String nationNmEn;
+  private String movieNm;
+
+  private String companyPartNm;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/GenreDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/GenreDto.java
@@ -3,19 +3,17 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Audit implements Serializable {
+public class GenreDto implements Serializable {
 
-  private static final long serialVersionUID = -2894116262379544856L;
+  private static final long serialVersionUID = -8848202206185624551L;
 
-  private String auditNo;
+  private String genreNm;
 
-  private String watchGrandeNm;
+  private String genreNmEn;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/NationDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/NationDto.java
@@ -3,19 +3,17 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class ShowType implements Serializable {
+public class NationDto implements Serializable {
 
-  private static final long serialVersionUID = -3550995663216297158L;
+  private static final long serialVersionUID = -4061994493958405357L;
 
-  private String showTypeGroupNm;
+  private String nationNm;
 
-  private String showTypeNm;
+  private String nationNmEn;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/PartDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/PartDto.java
@@ -3,21 +3,15 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Filmo implements Serializable {
+public class PartDto implements Serializable {
 
-  private static final long serialVersionUID = -4053066014700162783L;
-
-  private String movieCd;
-
-  private String movieNm;
+  private static final long serialVersionUID = -289346248160199690L;
 
   private String companyPartNm;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/ShowTypeDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/ShowTypeDto.java
@@ -3,17 +3,17 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Part implements Serializable {
+public class ShowTypeDto implements Serializable {
 
-  private static final long serialVersionUID = -289346248160199690L;
+  private static final long serialVersionUID = -3550995663216297158L;
 
-  private String companyPartNm;
+  private String showTypeGroupNm;
+
+  private String showTypeNm;
 }

--- a/src/main/java/inno/escape/moviebatch/global/model/dto/StaffDto.java
+++ b/src/main/java/inno/escape/moviebatch/global/model/dto/StaffDto.java
@@ -3,15 +3,13 @@ package inno.escape.moviebatch.global.model.dto;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-public class Staff implements Serializable {
+public class StaffDto implements Serializable {
 
   private static final long serialVersionUID = 7111697258327868403L;
 


### PR DESCRIPTION
* dto class 의 경우 이름 뒤에 dto 붙이기
* @Builder 애노테이션 대신 @Data 애노테이션 사용